### PR TITLE
Fix the secure creative resize

### DIFF
--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -75,8 +75,8 @@ function resizeRemoteCreative({ adUnitCode, width, height }) {
   // resize both container div + iframe
   ['div', 'iframe'].forEach(elmType => {
     let elementStyle = getElementByAdUnit(elmType).style;
-    elementStyle.width = width;
-    elementStyle.height = height;
+    elementStyle.width = `${width}px`;
+    elementStyle.height = `${height}px`;
   });
   function getElementByAdUnit(elmType) {
     return document


### PR DESCRIPTION
Setting the style without a unit only works in Quirks mode, ie without a `<DOCTYPE html>` at the beginning of the page. 