### PR TITLE
more tracking for secure creatives

### DIFF
--- a/modules/marfeelAnalyticsAdapter.js
+++ b/modules/marfeelAnalyticsAdapter.js
@@ -13,6 +13,7 @@ let AUCTION_END = CONSTANTS.EVENTS.AUCTION_END;
 let BID_WON = CONSTANTS.EVENTS.BID_WON;
 let BID_RESPONSE = CONSTANTS.EVENTS.BID_RESPONSE;
 let CONSENT_UPDATE = CONSTANTS.EVENTS.CMP_UPDATE;
+const ERROR_SECURE_CREATIVE = CONSTANTS.EVENTS.ERROR_SECURE_CREATIVE;
 
 let auctions = {};
 
@@ -35,6 +36,14 @@ function registerBidResponse(currentAuction, bid) {
   currentAuction.bidders.push(bid)
 }
 
+function sendErrorEvent(errorType, payload) {
+  const errorObject = {
+    category: errorType
+  };
+  Object.assign(errorObject, payload);
+  window.mrfpb && window.mrfpb.trackError(errorObject);
+}
+
 let marfeelAnalyticsAdapter = Object.assign(adapter({url, analyticsType}),
   {
     track({eventType, args}) {
@@ -49,6 +58,8 @@ let marfeelAnalyticsAdapter = Object.assign(adapter({url, analyticsType}),
         auctionEnd(auctions[args.auctionId], args);
       } else if (eventType === CONSENT_UPDATE) {
         registerCMPState(args);
+      } else if (eventType === ERROR_SECURE_CREATIVE) {
+        sendErrorEvent(eventType, args);
       }
     },
 

--- a/modules/marfeelAnalyticsAdapter.js
+++ b/modules/marfeelAnalyticsAdapter.js
@@ -41,7 +41,7 @@ function sendErrorEvent(errorType, payload) {
     category: errorType
   };
   Object.assign(errorObject, payload);
-  window.mrfpb && window.mrfpb.trackError(errorObject);
+  window.mrfpb && window.mrfpb.trackError && window.mrfpb.trackError(errorObject);
 }
 
 let marfeelAnalyticsAdapter = Object.assign(adapter({url, analyticsType}),

--- a/src/AnalyticsAdapter.js
+++ b/src/AnalyticsAdapter.js
@@ -16,7 +16,8 @@ const {
     BIDDER_DONE,
     SET_TARGETING,
     AD_RENDER_FAILED,
-    CMP_UPDATE
+    CMP_UPDATE,
+    ERROR_SECURE_CREATIVE
   }
 } = CONSTANTS;
 
@@ -112,7 +113,8 @@ export default function AnalyticsAdapter({ url, analyticsType, global, handler }
           args.config = typeof config === 'object' ? config.options || {} : {}; // enableAnaltyics configuration object
           this.enqueue({ eventType: AUCTION_INIT, args });
         },
-        [CMP_UPDATE]: args => this.enqueue({ eventType: CMP_UPDATE, args })
+        [CMP_UPDATE]: args => this.enqueue({ eventType: CMP_UPDATE, args }),
+        [ERROR_SECURE_CREATIVE]: args => this.enqueue({ eventType: ERROR_SECURE_CREATIVE, args })
       };
 
       utils._each(_handlers, (handler, event) => {

--- a/src/constants.json
+++ b/src/constants.json
@@ -36,7 +36,8 @@
     "REQUEST_BIDS": "requestBids",
     "ADD_AD_UNITS": "addAdUnits",
     "AD_RENDER_FAILED" : "adRenderFailed",
-    "CMP_UPDATE": "consentUpdate"
+	"CMP_UPDATE": "consentUpdate",
+	"ERROR_SECURE_CREATIVE": "secureCreative"
   },
   "AD_RENDER_FAILED_REASON" : {
     "PREVENT_WRITING_ON_MAIN_DOCUMENT": "preventWritingOnMainDocuemnt",

--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -98,9 +98,9 @@ function sendAdToCreative(adObject, remoteDomain, source) {
 function resizeRemoteCreative({ adUnitCode, width, height }) {
   // resize both container div + iframe
   ['div', 'iframe'].forEach(elmType => {
-    const element = getElementByAdUnit(elmType);
-    if (typeof element !== 'undefined') {
-      if (element === null) {
+    const nestedElement = getElementByAdUnit(elmType);
+    if (typeof nestedElement !== 'undefined') {
+      if (nestedElement === null) {
         events.emit(ERROR_SECURE_CREATIVE, {
           msg: 'No element of type "elmType" for adUnit',
           adUnitCode,
@@ -109,14 +109,14 @@ function resizeRemoteCreative({ adUnitCode, width, height }) {
           height
         });
       } else {
-        let elementStyle = element.style;
+        let elementStyle = nestedElement.style;
         elementStyle.width = `${width}px`;
         elementStyle.height = `${height}px`;
       }
     }
   });
   function getElementByAdUnit(elmType) {
-    const element = document.getElementById(
+    const containerElement = document.getElementById(
       find(
         window.googletag
           .pubads()
@@ -126,7 +126,7 @@ function resizeRemoteCreative({ adUnitCode, width, height }) {
       ).getSlotElementId()
     );
 
-    if (element === null) {
+    if (containerElement === null) {
       events.emit(ERROR_SECURE_CREATIVE, {
         msg: 'No element for adUnit',
         adUnitCode,
@@ -135,6 +135,6 @@ function resizeRemoteCreative({ adUnitCode, width, height }) {
       });
       return;
     }
-    return element.querySelector(elmType);
+    return containerElement.querySelector(elmType);
   }
 }

--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -12,6 +12,7 @@ import find from 'core-js/library/fn/array/find';
 
 const BID_WON = EVENTS.BID_WON;
 const ERROR_SECURE_CREATIVE = EVENTS.ERROR_SECURE_CREATIVE;
+
 export function listenMessagesFromCreative() {
   addEventListener('message', receiveMessage, false);
 }
@@ -39,15 +40,12 @@ function receiveMessage(ev) {
           source: ev.source
         });
       }
-
       if (typeof ev.source === 'undefined') {
         events.emit(ERROR_SECURE_CREATIVE, {
           msg: 'event source is undefined',
           data,
           adObject
         });
-        // track something
-        // the iframe was removed before we treated it ? => this could happen after a lot of swiping!
       }
       if (typeof adObject === 'undefined') {
         events.emit(ERROR_SECURE_CREATIVE, {
@@ -55,8 +53,6 @@ function receiveMessage(ev) {
           data,
           source: ev.source
         });
-        // track something.
-        // It would mean I have sent the wrong adId ? -> If I have sent any!
       }
 
       sendAdToCreative(adObject, data.adServerDomain, ev.source);
@@ -66,8 +62,6 @@ function receiveMessage(ev) {
 
       events.emit(BID_WON, adObject);
     }
-
-    // adObject might be undefined
 
     // handle this script from native template in an ad server
     // window.parent.postMessage(JSON.stringify({


### PR DESCRIPTION
The additional tracking happens in all the places where we currently have Kibana errors. 
I'm expecting to either:
* figure out that other values are undefined / misdefined when those errors fire
* See that those errors are false positives, if the user has a content blocker / has swiped already... In which case I would silence those errors in the specific cases I understand. 
This goes with the XP PR creating the `mrfpb.trackError` method: https://github.com/Marfeel/MarfeelXP/pull/9046

Feel free to suggest improvements to track better!